### PR TITLE
Improve Elo simulation robustness and add automated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # elo-elo
-An elo rating implementation
+
+An elo rating implementation.
+
+## Development
+
+```bash
+npm test
+npm run build
+```
+
+The test suite exercises the core Elo calculations, verifies that matches are
+recorded correctly (including edge-cases such as zero scores), and ensures the
+simulation averages multiple runs deterministically.

--- a/lib/fight.js
+++ b/lib/fight.js
@@ -9,7 +9,7 @@ exports["default"] = void 0;
 
 var utils = _interopRequireWildcard(require("./utils"));
 
-var _getNewElo7 = _interopRequireDefault(require("./getNewElo"));
+var _getNewElo3 = _interopRequireDefault(require("./getNewElo"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -29,6 +29,81 @@ function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
+var ensureDifferentPlayers = function ensureDifferentPlayers(players, currentPlayer) {
+  if (Object.keys(players).length <= 1) {
+    return currentPlayer;
+  }
+
+  var opponent = utils.randomKey(players);
+
+  while (opponent === currentPlayer) {
+    opponent = utils.randomKey(players);
+  }
+
+  return opponent;
+};
+
+var calculateOutcomeScores = function calculateOutcomeScores(player1Score, player2Score) {
+  if (player1Score < player2Score) {
+    return {
+      outcome: 1,
+      scores: [1, 0]
+    };
+  }
+
+  if (player1Score > player2Score) {
+    return {
+      outcome: -1,
+      scores: [0, 1]
+    };
+  }
+
+  return {
+    outcome: 0,
+    scores: [0.5, 0.5]
+  };
+};
+
+var updateOutcomeTallies = function updateOutcomeTallies(player1, player2, outcome) {
+  if (outcome === 1) {
+    player1.w += 1;
+    player2.l += 1;
+    return;
+  }
+
+  if (outcome === -1) {
+    player2.w += 1;
+    player1.l += 1;
+    return;
+  }
+
+  player1.d += 1;
+  player2.d += 1;
+};
+
+var updateEloForMatch = function updateEloForMatch(player1, player2, scores, kFactor, gravity, energy, baseline, secondHalf) {
+  var _getNewElo = (0, _getNewElo3["default"])({
+    elo: player1.elo,
+    score: scores[0]
+  }, {
+    elo: player2.elo,
+    score: scores[1]
+  }, kFactor, gravity, energy, baseline),
+      _getNewElo2 = _slicedToArray(_getNewElo, 2),
+      newPlayer1Elo = _getNewElo2[0],
+      newPlayer2Elo = _getNewElo2[1];
+
+  player1.elo = newPlayer1Elo;
+  player2.elo = newPlayer2Elo;
+  player1.totalElo += newPlayer1Elo;
+  player2.totalElo += newPlayer2Elo;
+
+  if (secondHalf) {
+    player1.totalSecondHalfElo += newPlayer1Elo;
+    player2.totalSecondHalfElo += newPlayer2Elo;
+  }
+};
+
 var fight = function fight(indexData, coeficients) {
   var kFactor = coeficients.kFactor,
       gravity = coeficients.gravity,
@@ -39,101 +114,58 @@ var fight = function fight(indexData, coeficients) {
   var secondHalf = false;
 
   for (var i = 0; i < fights; i++) {
-    secondHalf = secondHalf || i > fights / 2;
-    var player1 = utils.randomKey(eloData);
-    var player2 = utils.randomKey(eloData);
-    var indexName = utils.randomKey(indexData[player1]);
-    var player1score = indexData[player1][indexName];
-    var player2score = indexData[player2][indexName];
-    eloData[player1].attemptedGames++;
-    eloData[player2].attemptedGames++;
+    secondHalf = secondHalf || i >= fights / 2;
+    var player1Name = utils.randomKey(eloData);
+    var player2Name = ensureDifferentPlayers(eloData, player1Name);
+    var player1Indexes = indexData[player1Name];
 
-    if (player1score && player2score) {
-      eloData[player1].games++;
-      eloData[player2].games++;
-
-      if (secondHalf) {
-        eloData[player1].secondHalfGames++;
-        eloData[player2].secondHalfGames++;
-      }
-
-      if (player1score < player2score) {
-        // player1 wins
-        eloData[player1].w++;
-        eloData[player2].l++;
-
-        var _getNewElo = (0, _getNewElo7["default"])({
-          elo: eloData[player1].elo,
-          score: 1
-        }, {
-          elo: eloData[player2].elo,
-          score: 0
-        }, kFactor, gravity, energy, baseline),
-            _getNewElo2 = _slicedToArray(_getNewElo, 2),
-            newPlayer1Elo = _getNewElo2[0],
-            newPlayer2Elo = _getNewElo2[1];
-
-        eloData[player1].elo = newPlayer1Elo;
-        eloData[player2].elo = newPlayer2Elo;
-        eloData[player1].totalElo += newPlayer1Elo;
-        eloData[player2].totalElo += newPlayer2Elo;
-
-        if (secondHalf) {
-          eloData[player1].totalSecondHalfElo += newPlayer1Elo;
-          eloData[player2].totalSecondHalfElo += newPlayer2Elo;
-        }
-      } else if (player1score > player2score) {
-        // player2 wins
-        eloData[player2].w++;
-        eloData[player1].l++;
-
-        var _getNewElo3 = (0, _getNewElo7["default"])({
-          elo: eloData[player1].elo,
-          score: 0
-        }, {
-          elo: eloData[player2].elo,
-          score: 1
-        }, kFactor, gravity, energy, baseline),
-            _getNewElo4 = _slicedToArray(_getNewElo3, 2),
-            _newPlayer1Elo = _getNewElo4[0],
-            _newPlayer2Elo = _getNewElo4[1];
-
-        eloData[player1].elo = _newPlayer1Elo;
-        eloData[player2].elo = _newPlayer2Elo;
-        eloData[player1].totalElo += _newPlayer1Elo;
-        eloData[player2].totalElo += _newPlayer2Elo;
-
-        if (secondHalf) {
-          eloData[player1].totalSecondHalfElo += _newPlayer1Elo;
-          eloData[player2].totalSecondHalfElo += _newPlayer2Elo;
-        }
-      } else {
-        // draw
-        eloData[player1].d++;
-        eloData[player2].d++;
-
-        var _getNewElo5 = (0, _getNewElo7["default"])({
-          elo: eloData[player1].elo,
-          score: 0.5
-        }, {
-          elo: eloData[player2].elo,
-          score: 0.5
-        }, kFactor, gravity, energy, baseline),
-            _getNewElo6 = _slicedToArray(_getNewElo5, 2),
-            _newPlayer1Elo2 = _getNewElo6[0],
-            _newPlayer2Elo2 = _getNewElo6[1];
-
-        eloData[player1].elo = _newPlayer1Elo2;
-        eloData[player2].elo = _newPlayer2Elo2;
-        eloData[player1].totalElo += _newPlayer1Elo2;
-        eloData[player2].totalElo += _newPlayer2Elo2;
-
-        if (secondHalf) {
-          eloData[player1].totalSecondHalfElo += _newPlayer1Elo2;
-          eloData[player2].totalSecondHalfElo += _newPlayer2Elo2;
-        }
-      }
+    if (!player1Indexes) {
+      continue;
     }
+
+    var indexName = void 0;
+
+    try {
+      indexName = utils.randomKey(player1Indexes);
+    } catch (error) {
+      continue;
+    }
+
+    if (player1Name === player2Name) {
+      continue;
+    }
+
+    var player2Indexes = indexData[player2Name];
+
+    if (!player2Indexes || !(indexName in player2Indexes)) {
+      continue;
+    }
+
+    var player1Score = player1Indexes[indexName];
+    var player2Score = player2Indexes[indexName];
+    var player1 = eloData[player1Name];
+    var player2 = eloData[player2Name];
+    player1.attemptedGames += 1;
+    player2.attemptedGames += 1;
+
+    if (player1Score == null || player2Score == null) {
+      continue;
+    }
+
+    player1.games += 1;
+    player2.games += 1;
+
+    if (secondHalf) {
+      player1.secondHalfGames += 1;
+      player2.secondHalfGames += 1;
+    }
+
+    var _calculateOutcomeScor = calculateOutcomeScores(player1Score, player2Score),
+        outcome = _calculateOutcomeScor.outcome,
+        scores = _calculateOutcomeScor.scores;
+
+    updateOutcomeTallies(player1, player2, outcome);
+    updateEloForMatch(player1, player2, scores, kFactor, gravity, energy, baseline, secondHalf);
   }
 
   return eloData;

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,45 +17,78 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
+var createAccumulator = function createAccumulator(referenceRun) {
+  return Object.keys(referenceRun).reduce(function (accumulator, cityName) {
+    return _objectSpread(_objectSpread({}, accumulator), {}, _defineProperty({}, cityName, Object.keys(referenceRun[cityName]).reduce(function (cityAccumulator, statKey) {
+      return _objectSpread(_objectSpread({}, cityAccumulator), {}, _defineProperty({}, statKey, 0));
+    }, {})));
+  }, {});
+};
+
+var addRunToAccumulator = function addRunToAccumulator(accumulator, run) {
+  Object.keys(run).forEach(function (cityName) {
+    if (!accumulator[cityName]) {
+      accumulator[cityName] = Object.keys(run[cityName]).reduce(function (cityAccumulator, statKey) {
+        return _objectSpread(_objectSpread({}, cityAccumulator), {}, _defineProperty({}, statKey, 0));
+      }, {});
+    }
+
+    Object.keys(run[cityName]).forEach(function (statKey) {
+      accumulator[cityName][statKey] += run[cityName][statKey];
+    });
+  });
+  return accumulator;
+};
+
+var averageAccumulator = function averageAccumulator(accumulator, runs) {
+  return Object.keys(accumulator).reduce(function (average, cityName) {
+    return _objectSpread(_objectSpread({}, average), {}, _defineProperty({}, cityName, Object.keys(accumulator[cityName]).reduce(function (cityAverage, statKey) {
+      return _objectSpread(_objectSpread({}, cityAverage), {}, _defineProperty({}, statKey, accumulator[cityName][statKey] / runs));
+    }, {})));
+  }, {});
+};
+
 function simulation(indexData, coeficients) {
-  var runs, outputs, i, averageOutput;
+  var runs, accumulator, i, runResult;
   return regeneratorRuntime.wrap(function simulation$(_context) {
     while (1) {
       switch (_context.prev = _context.next) {
         case 0:
           runs = coeficients.runs;
-          outputs = [];
-          i = 0;
 
-        case 3:
-          if (!(i < runs)) {
-            _context.next = 10;
+          if (!(!Number.isInteger(runs) || runs <= 0)) {
+            _context.next = 3;
             break;
           }
 
-          outputs.push((0, _fight["default"])(indexData, coeficients));
-          _context.next = 7;
+          throw new Error("runs must be a positive integer");
+
+        case 3:
+          i = 0;
+
+        case 4:
+          if (!(i < runs)) {
+            _context.next = 12;
+            break;
+          }
+
+          runResult = (0, _fight["default"])(indexData, coeficients);
+          accumulator = accumulator ? addRunToAccumulator(accumulator, runResult) : addRunToAccumulator(createAccumulator(runResult), runResult);
+          _context.next = 9;
           return {
-            progress: i / runs,
+            progress: (i + 1) / runs,
             random: Math.random()
           };
 
-        case 7:
+        case 9:
           i++;
-          _context.next = 3;
+          _context.next = 4;
           break;
 
-        case 10:
-          averageOutput = outputs.reduce(function (acc, output) {
-            return Object.keys(output).reduce(function (outputAcc, cityName) {
-              return _objectSpread(_objectSpread({}, outputAcc), {}, _defineProperty({}, cityName, Object.keys(output[cityName]).reduce(function (cityEloStatsAcc, eloStat) {
-                return _objectSpread(_objectSpread({}, cityEloStatsAcc), {}, _defineProperty({}, eloStat, output[cityName][eloStat] / outputs.length + (acc[cityName] ? acc[cityName][eloStat] : 0)));
-              }, {})));
-            }, {});
-          }, {});
-          return _context.abrupt("return", averageOutput);
-
         case 12:
+          return _context.abrupt("return", averageAccumulator(accumulator, runs));
+
+        case 13:
         case "end":
           return _context.stop();
       }

--- a/lib/utils/randomKey.js
+++ b/lib/utils/randomKey.js
@@ -4,18 +4,22 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports["default"] = void 0;
-var objKeysMap = new Map();
+var objKeysMap = new WeakMap();
+
+var getKeys = function getKeys(obj) {
+  if (!objKeysMap.has(obj)) {
+    objKeysMap.set(obj, Object.keys(obj));
+  }
+
+  return objKeysMap.get(obj);
+};
 
 var randomKey = function randomKey(obj) {
-  var keys = [];
+  var keys = getKeys(obj);
 
-  if (objKeysMap.has(obj)) {
-    keys = objKeysMap.get(obj);
-  } else {
-    keys = Object.keys(obj);
-    objKeysMap.set(obj, keys);
-  } // const keys = Object.keys(obj);
-
+  if (!keys.length) {
+    throw new Error("Cannot select a random key from an empty object");
+  }
 
   return keys[Math.floor(keys.length * Math.random())];
 };

--- a/src/fight.spec.js
+++ b/src/fight.spec.js
@@ -1,0 +1,72 @@
+jest.mock("./utils", () => {
+  const actual = jest.requireActual("./utils");
+
+  return {
+    ...actual,
+    randomKey: jest.fn(),
+  };
+});
+
+import fight from "./fight";
+import * as utils from "./utils";
+
+describe("fight", () => {
+  const coefficients = {
+    kFactor: 32,
+    gravity: 0,
+    energy: 400,
+    baseline: 1000,
+    fights: 1,
+  };
+
+  afterEach(() => {
+    utils.randomKey.mockReset();
+  });
+
+  it("records games where a player has a score of zero", () => {
+    utils.randomKey
+      .mockImplementationOnce(() => "alpha")
+      .mockImplementationOnce(() => "beta")
+      .mockImplementationOnce(() => "metric")
+      .mockImplementation(() => {
+        throw new Error("Unexpected call to randomKey");
+      });
+
+    const indexData = {
+      alpha: { metric: 0 },
+      beta: { metric: 1 },
+    };
+
+    const result = fight(indexData, coefficients);
+
+    expect(result.alpha.games).toBe(1);
+    expect(result.beta.games).toBe(1);
+    expect(result.alpha.w).toBe(1);
+    expect(result.beta.l).toBe(1);
+    expect(result.alpha.attemptedGames).toBe(1);
+    expect(result.beta.attemptedGames).toBe(1);
+    expect(result.alpha.elo).toBeGreaterThan(result.beta.elo);
+  });
+
+  it("skips rounds when an opponent lacks the requested index", () => {
+    utils.randomKey
+      .mockImplementationOnce(() => "alpha")
+      .mockImplementationOnce(() => "beta")
+      .mockImplementationOnce(() => "metric")
+      .mockImplementation(() => {
+        throw new Error("Unexpected call to randomKey");
+      });
+
+    const indexData = {
+      alpha: { metric: 1 },
+      beta: {},
+    };
+
+    const result = fight(indexData, coefficients);
+
+    expect(result.alpha.games).toBe(0);
+    expect(result.beta.games).toBe(0);
+    expect(result.alpha.attemptedGames).toBe(0);
+    expect(result.beta.attemptedGames).toBe(0);
+  });
+});

--- a/src/getNewElo.spec.js
+++ b/src/getNewElo.spec.js
@@ -1,0 +1,33 @@
+import getNewElo from "./getNewElo";
+
+describe("getNewElo", () => {
+  it("updates Elo using the classic formula when gravity is zero", () => {
+    const [player1Elo, player2Elo] = getNewElo(
+      { elo: 1000, score: 1 },
+      { elo: 1000, score: 0 },
+      32,
+      0,
+      400,
+      1000,
+    );
+
+    expect(player1Elo).toBeCloseTo(1016);
+    expect(player2Elo).toBeCloseTo(984);
+  });
+
+  it("pulls the ratings towards the baseline when gravity is applied", () => {
+    const [player1Elo, player2Elo] = getNewElo(
+      { elo: 1200, score: 0 },
+      { elo: 900, score: 1 },
+      40,
+      0.1,
+      400,
+      1000,
+    );
+
+    expect(player1Elo).toBeLessThan(1200);
+    expect(player1Elo).toBeGreaterThan(1100);
+    expect(player2Elo).toBeGreaterThan(900);
+    expect(player2Elo).toBeLessThan(1100);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,38 +1,75 @@
 import fight from "./fight";
 
+const createAccumulator = referenceRun =>
+  Object.keys(referenceRun).reduce(
+    (accumulator, cityName) => ({
+      ...accumulator,
+      [cityName]: Object.keys(referenceRun[cityName]).reduce(
+        (cityAccumulator, statKey) => ({
+          ...cityAccumulator,
+          [statKey]: 0,
+        }),
+        {},
+      ),
+    }),
+    {},
+  );
+
+const addRunToAccumulator = (accumulator, run) => {
+  Object.keys(run).forEach(cityName => {
+    if (!accumulator[cityName]) {
+      accumulator[cityName] = Object.keys(run[cityName]).reduce(
+        (cityAccumulator, statKey) => ({
+          ...cityAccumulator,
+          [statKey]: 0,
+        }),
+        {},
+      );
+    }
+
+    Object.keys(run[cityName]).forEach(statKey => {
+      accumulator[cityName][statKey] += run[cityName][statKey];
+    });
+  });
+
+  return accumulator;
+};
+
+const averageAccumulator = (accumulator, runs) =>
+  Object.keys(accumulator).reduce(
+    (average, cityName) => ({
+      ...average,
+      [cityName]: Object.keys(accumulator[cityName]).reduce(
+        (cityAverage, statKey) => ({
+          ...cityAverage,
+          [statKey]: accumulator[cityName][statKey] / runs,
+        }),
+        {},
+      ),
+    }),
+    {},
+  );
+
 export default function* simulation(indexData, coeficients) {
-	const { runs } = coeficients;
+  const { runs } = coeficients;
 
-	const outputs = [];
+  if (!Number.isInteger(runs) || runs <= 0) {
+    throw new Error("runs must be a positive integer");
+  }
 
-	for (var i = 0; i < runs; i++) {
-		outputs.push(fight(indexData, coeficients));
+  let accumulator;
 
-		yield {
-			progress: i / runs,
-			random: Math.random()
-		};
-	}
+  for (let i = 0; i < runs; i++) {
+    const runResult = fight(indexData, coeficients);
+    accumulator = accumulator
+      ? addRunToAccumulator(accumulator, runResult)
+      : addRunToAccumulator(createAccumulator(runResult), runResult);
 
-	const averageOutput = outputs.reduce(
-		(acc, output) =>
-			Object.keys(output).reduce(
-				(outputAcc, cityName) => ({
-					...outputAcc,
-					[cityName]: Object.keys(output[cityName]).reduce(
-						(cityEloStatsAcc, eloStat) => ({
-							...cityEloStatsAcc,
-							[eloStat]:
-								output[cityName][eloStat] / outputs.length +
-								(acc[cityName] ? acc[cityName][eloStat] : 0)
-						}),
-						{}
-					)
-				}),
-				{}
-			),
-		{}
-	);
+    yield {
+      progress: (i + 1) / runs,
+      random: Math.random(),
+    };
+  }
 
-	return averageOutput;
+  return averageAccumulator(accumulator, runs);
 }

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1,0 +1,88 @@
+import "regenerator-runtime/runtime";
+
+import simulation from "./index";
+import fight from "./fight";
+
+jest.mock("./fight", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe("simulation", () => {
+  const originalRandom = Math.random;
+
+  afterEach(() => {
+    Math.random = originalRandom;
+    jest.clearAllMocks();
+  });
+
+  it("aggregates Elo data across multiple runs", () => {
+    const runOne = {
+      Alpha: {
+        elo: 1100,
+        w: 2,
+        l: 0,
+        d: 0,
+        games: 2,
+        secondHalfGames: 0,
+        attemptedGames: 2,
+        totalElo: 2200,
+        totalSecondHalfElo: 0,
+      },
+    };
+
+    const runTwo = {
+      Alpha: {
+        elo: 1200,
+        w: 3,
+        l: 0,
+        d: 0,
+        games: 3,
+        secondHalfGames: 1,
+        attemptedGames: 3,
+        totalElo: 3600,
+        totalSecondHalfElo: 1200,
+      },
+    };
+
+    fight
+      .mockReturnValueOnce(runOne)
+      .mockReturnValueOnce(runTwo);
+
+    Math.random = jest.fn(() => 0.5);
+
+    const iterator = simulation({}, { runs: 2 });
+
+    const firstStep = iterator.next();
+    expect(firstStep.done).toBe(false);
+    expect(firstStep.value.progress).toBeCloseTo(0.5);
+    expect(firstStep.value.random).toBe(0.5);
+
+    const secondStep = iterator.next();
+    expect(secondStep.done).toBe(false);
+    expect(secondStep.value.progress).toBeCloseTo(1);
+
+    const completion = iterator.next();
+    expect(completion.done).toBe(true);
+
+    expect(completion.value.Alpha).toEqual({
+      elo: 1150,
+      w: 2.5,
+      l: 0,
+      d: 0,
+      games: 2.5,
+      secondHalfGames: 0.5,
+      attemptedGames: 2.5,
+      totalElo: 2900,
+      totalSecondHalfElo: 600,
+    });
+
+    expect(fight).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when runs is not a positive integer", () => {
+    const iterator = simulation({}, { runs: 0 });
+
+    expect(() => iterator.next()).toThrow("runs must be a positive integer");
+  });
+});

--- a/src/utils/randomKey.js
+++ b/src/utils/randomKey.js
@@ -1,16 +1,21 @@
-const objKeysMap = new Map();
+const objKeysMap = new WeakMap();
+
+const getKeys = obj => {
+  if (!objKeysMap.has(obj)) {
+    objKeysMap.set(obj, Object.keys(obj));
+  }
+
+  return objKeysMap.get(obj);
+};
 
 const randomKey = obj => {
-	let keys = [];
+  const keys = getKeys(obj);
 
-	if (objKeysMap.has(obj)) {
-		keys = objKeysMap.get(obj);
-	} else {
-		keys = Object.keys(obj);
-		objKeysMap.set(obj, keys);
-	}
-	// const keys = Object.keys(obj);
-	return keys[Math.floor(keys.length * Math.random())];
+  if (!keys.length) {
+    throw new Error("Cannot select a random key from an empty object");
+  }
+
+  return keys[Math.floor(keys.length * Math.random())];
 };
 
 export default randomKey;

--- a/src/utils/randomKey.spec.js
+++ b/src/utils/randomKey.spec.js
@@ -1,0 +1,42 @@
+import randomKey from "./randomKey";
+
+describe("randomKey", () => {
+  const originalRandom = Math.random;
+
+  afterEach(() => {
+    Math.random = originalRandom;
+  });
+
+  it("returns a key using the provided random function", () => {
+    Math.random = jest.fn(() => 0.49);
+    const result = randomKey({ alpha: 1, beta: 2 });
+
+    expect(result).toBe("alpha");
+  });
+
+  it("reuses cached keys for repeated calls", () => {
+    Math.random = jest.fn(() => 0.9);
+    const keysSpy = jest.spyOn(Object, "keys");
+
+    const target = { first: true, second: true };
+
+    const initialCalls = keysSpy.mock.calls.length;
+
+    try {
+      randomKey(target);
+      randomKey(target);
+
+      const newCalls = keysSpy.mock.calls.length - initialCalls;
+
+      expect(newCalls).toBe(1);
+    } finally {
+      keysSpy.mockRestore();
+    }
+  });
+
+  it("throws when the object has no keys", () => {
+    expect(() => randomKey({})).toThrow(
+      "Cannot select a random key from an empty object",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- rework the simulation generator to accumulate results efficiently and validate the requested run count
- tighten fight matching logic to handle missing data, zero scores, and avoid duplicate competitors
- harden random key selection while documenting and testing the core Elo behaviour

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8f44f55f083289e618a954e1a46bd